### PR TITLE
Unmarshal scalars and null to arrays

### DIFF
--- a/src/main/php/util/data/Marshalling.class.php
+++ b/src/main/php/util/data/Marshalling.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\data;
 
+use Traversable;
 use lang\{ArrayType, Enum, MapType, Reflection, Type, XPClass};
 use util\{Bytes, Currency, Date, Money, XPIterator};
 
@@ -84,14 +85,14 @@ class Marshalling {
     } else if ($t instanceof ArrayType || $t instanceof MapType) {
       $t= $t->componentType();
       $r= [];
-      foreach ($value instanceof \Traversable ? $value : (array)$value as $k => $v) {
+      foreach ($value instanceof Traversable ? $value : (array)$value as $k => $v) {
         $r[$k]= $this->unmarshal($v, $t);
       }
       return $r;
     } else if ($t === Type::$ARRAY) {
       $t= Type::$VAR;
       $r= [];
-      foreach ($value instanceof \Traversable ? $value : (array)$value as $k => $v) {
+      foreach ($value instanceof Traversable ? $value : (array)$value as $k => $v) {
         $r[$k]= $this->unmarshal($v, $t);
       }
       return $r;
@@ -143,7 +144,7 @@ class Marshalling {
       return ['amount' => $value->amount(), 'currency' => $value->currency()->name()];
     } else if ($value instanceof Enum) {
       return $value->name();
-    } else if ($value instanceof \Traversable) {
+    } else if ($value instanceof Traversable) {
       return $this->generator($value);
     } else if ($value instanceof XPIterator) {
       return $this->iterator($value);

--- a/src/main/php/util/data/Marshalling.class.php
+++ b/src/main/php/util/data/Marshalling.class.php
@@ -1,26 +1,18 @@
 <?php namespace util\data;
 
-use lang\ArrayType;
-use lang\Enum;
-use lang\MapType;
-use lang\Type;
-use lang\XPClass;
-use util\Bytes;
-use util\Currency;
-use util\Date;
-use util\Money;
-use util\XPIterator;
+use lang\{ArrayType, Enum, MapType, Type, XPClass};
+use util\{Bytes, Currency, Date, Money, XPIterator};
 
 /**
  * Takes care of converting objects from and to maps
  *
- * @test  xp://util.data.unittest.MarshallingTest
- * @test  xp://util.data.unittest.PrimitivesTest
- * @test  xp://util.data.unittest.BytesTest
- * @test  xp://util.data.unittest.DatesTest
- * @test  xp://util.data.unittest.EnumsTest
- * @test  xp://util.data.unittest.MoneyTest
- * @test  xp://util.data.unittest.ObjectsTest
+ * @test  util.data.unittest.MarshallingTest
+ * @test  util.data.unittest.PrimitivesTest
+ * @test  util.data.unittest.BytesTest
+ * @test  util.data.unittest.DatesTest
+ * @test  util.data.unittest.EnumsTest
+ * @test  util.data.unittest.MoneyTest
+ * @test  util.data.unittest.ObjectsTest
  */
 class Marshalling {
 
@@ -107,14 +99,14 @@ class Marshalling {
     } else if ($t instanceof ArrayType || $t instanceof MapType) {
       $t= $t->componentType();
       $r= [];
-      foreach ($value as $k => $v) {
+      foreach ($value instanceof \Traversable ? $value : (array)$value as $k => $v) {
         $r[$k]= $this->unmarshal($v, $t);
       }
       return $r;
     } else if ($t === Type::$ARRAY) {
       $t= Type::$VAR;
       $r= [];
-      foreach ($value as $k => $v) {
+      foreach ($value instanceof \Traversable ? $value : (array)$value as $k => $v) {
         $r[$k]= $this->unmarshal($v, $t);
       }
       return $r;

--- a/src/test/php/util/data/unittest/IterablesTest.class.php
+++ b/src/test/php/util/data/unittest/IterablesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\data\unittest;
 
 use lang\Type;
-use test\{Assert, Test};
+use test\{Assert, Test, Values};
 use util\XPIterator;
 use util\data\Marshalling;
 
@@ -87,5 +87,26 @@ class IterablesTest {
       $result[]= $it->next();
     }
     Assert::equals([1, 2, 3], $result);
+  }
+
+  #[Test, Values([[[1, 2, 3]], [['color' => 'green']]])]
+  public function unmarshal_array_to_array($value) {
+    Assert::equals($value, (new Marshalling())->unmarshal($value, Type::$ARRAY));
+  }
+
+  #[Test]
+  public function unmarshal_iterable_to_array() {
+    $f= function() { yield 1; yield 2; yield 3; };
+    Assert::equals([1, 2, 3], (new Marshalling())->unmarshal($f(), Type::$ARRAY));
+  }
+
+  #[Test, Values(['one', 1, 0, -1.5, true, false])]
+  public function unmarshal_scalar_to_array() {
+    Assert::equals([], (new Marshalling())->unmarshal(null, Type::$ARRAY));
+  }
+
+  #[Test]
+  public function unmarshal_null_to_array() {
+    Assert::equals([], (new Marshalling())->unmarshal(null, Type::$ARRAY));
   }
 }


### PR DESCRIPTION
Given the following code:

```php
$value= (new Marshalling())->unmarshal($input, Type::$ARRAY);
```

...the results are the following:

| Input                           | Result before | Result after |
| ------------------------------- | ------------- | ------------ |
| `[]`                            | `[]`          | `[]`         |
| `[1, 2, 3]`                     | `[1, 2, 3]`   | `[1, 2, 3]`  |
| `(function() { yield 1; })()`   | `[1]`         | `[1]`        |
| `"one"`                         | `[]` + ⚠️       | `["one"]`    |
| `null`                          | `[]` + ⚠️      | `[]`         |

⚠️ Raises the following warning: *foreach() argument must be of type array|object, ... given*