### PR TITLE
Keep empty objects intact

### DIFF
--- a/src/main/php/util/data/Marshalling.class.php
+++ b/src/main/php/util/data/Marshalling.class.php
@@ -164,7 +164,7 @@ class Marshalling {
           $r[$name]= $this->marshal($p->get($value, $reflect));
         }
       }
-      return $r;
+      return empty($r) ? (object)$r : $r;
     } else if (is_array($value)) {
       $r= [];
       foreach ($value as $k => $v) {

--- a/src/test/php/util/data/unittest/MarshallingTest.class.php
+++ b/src/test/php/util/data/unittest/MarshallingTest.class.php
@@ -16,6 +16,11 @@ class MarshallingTest {
     Assert::equals(1, (new Marshalling())->marshal(1));
   }
 
+  #[Test]
+  public function objects() {
+    Assert::equals((object)[], (new Marshalling())->marshal((object)[]));
+  }
+
   #[Test, Values(eval: '["var", Type::$VAR]')]
   public function unmarshal($type) {
     Assert::equals(1, (new Marshalling())->unmarshal(1, $type));


### PR DESCRIPTION
Some REST APIs expect empty objects as `{}` and will choke on them being transmitted as `[]`. Currently there is no way to transmit these, as the marshalling library will convert `(object)[]` back to an array.

## Example: OpenAI API

```
[15:32:31  7830 debug] {
  "error": {
    "message": "Invalid schema for function 'testing_hello': [] is not of type 'object'",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
}
```