### PR TITLE
Add mapping() and resolving() to supply custom (un)marshalling logic

### DIFF
--- a/src/test/php/util/data/unittest/MarshallingTest.class.php
+++ b/src/test/php/util/data/unittest/MarshallingTest.class.php
@@ -36,7 +36,7 @@ class MarshallingTest {
   public function mapping() {
     $marshalling= (new Marshalling())->mapping(
       Person::class,
-      fn($person) => ['id' => $person->id()]
+      function($person) { return ['id' => $person->id()]; }
     );
 
     Assert::equals(['id' => 6100], $marshalling->marshal(new Person(6100, 'Test')));
@@ -46,7 +46,7 @@ class MarshallingTest {
   public function resolving() {
     $marshalling= (new Marshalling())->resolving(
       Person::class,
-      fn($value) => new Person($value['id'], 'Test')
+      function($value) { return new Person($value['id'], 'Test'); }
     );
 
     Assert::equals(new Person(6100, 'Test'), $marshalling->unmarshal(['id' => 6100], Person::class));

--- a/src/test/php/util/data/unittest/MarshallingTest.class.php
+++ b/src/test/php/util/data/unittest/MarshallingTest.class.php
@@ -3,6 +3,7 @@
 use lang\Type;
 use test\{Assert, Test, Values};
 use util\data\Marshalling;
+use util\data\unittest\fixtures\Person;
 
 class MarshallingTest {
 
@@ -29,5 +30,25 @@ class MarshallingTest {
   #[Test]
   public function unmarshal_without_type() {
     Assert::equals(1, (new Marshalling())->unmarshal(1));
+  }
+
+  #[Test]
+  public function mapping() {
+    $marshalling= (new Marshalling())->mapping(
+      Person::class,
+      fn($person) => ['id' => $person->id()]
+    );
+
+    Assert::equals(['id' => 6100], $marshalling->marshal(new Person(6100, 'Test')));
+  }
+
+  #[Test]
+  public function resolving() {
+    $marshalling= (new Marshalling())->resolving(
+      Person::class,
+      fn($value) => new Person($value['id'], 'Test')
+    );
+
+    Assert::equals(new Person(6100, 'Test'), $marshalling->unmarshal(['id' => 6100], Person::class));
   }
 }


### PR DESCRIPTION
Given the following user type:

```php
class User {
  public function __construct(public int $id, public string $name) { }
}
```

## Defaults

```php
$marshalling= new Marshalling();
$value= $marshalling->marshal(new User(0, 'root'));
// ['id' => 0, 'name' => 'root']

$user= $marshalling->unmarshal($value, User::class);
// User(id: 0, name: 'root')
```

## Custom logic

```php
$marshalling= (new Marshalling())
  ->mapping(User::class, fn($user) => ['uid' => $user->id])
  ->resolving(User::class, fn($value) => new User($value['uid'], posix_getpwuid($value['uid'])['name'])
;
$value= $marshalling->marshal(new User(0, 'root'));
// ['uid' => 0]

$user= $marshalling->unmarshal($value, User::class);
// User(id: 0, name: 'root')
```