### PR TITLE
Refactor mapping for classes inside `util`, making them overrideable

### DIFF
--- a/src/test/php/util/data/unittest/BytesTest.class.php
+++ b/src/test/php/util/data/unittest/BytesTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\data\unittest;
 
-use test\Assert;
-use test\{Test, TestCase};
+use test\{Assert, Test};
 use util\Bytes;
 use util\data\Marshalling;
 

--- a/src/test/php/util/data/unittest/DatesTest.class.php
+++ b/src/test/php/util/data/unittest/DatesTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\data\unittest;
 
-use test\Assert;
-use test\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use util\Date;
 use util\data\Marshalling;
 

--- a/src/test/php/util/data/unittest/EnumsTest.class.php
+++ b/src/test/php/util/data/unittest/EnumsTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\data\unittest;
 
-use test\Assert;
-use test\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use util\Currency;
 use util\data\Marshalling;
 

--- a/src/test/php/util/data/unittest/MoneyTest.class.php
+++ b/src/test/php/util/data/unittest/MoneyTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\data\unittest;
 
-use test\Assert;
-use test\{Test, TestCase};
+use test\{Assert, Test};
 use util\data\Marshalling;
 use util\{Currency, Money};
 

--- a/src/test/php/util/data/unittest/PrimitivesTest.class.php
+++ b/src/test/php/util/data/unittest/PrimitivesTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\data\unittest;
 
-use test\Assert;
-use test\{Test, TestCase, Values};
+use test\{Assert, Test, Values};
 use util\data\Marshalling;
 
 class PrimitivesTest {


### PR DESCRIPTION
This affects `util.Date`, `util.Money`, `util.Bytes` and `util.XPIterator`.

See #7