### PR TITLE
Support unmarshalling to nullable types

### DIFF
--- a/src/main/php/util/data/Marshalling.class.php
+++ b/src/main/php/util/data/Marshalling.class.php
@@ -114,7 +114,7 @@ class Marshalling {
 
       foreach ($reflect->properties() as $name => $p) {
         $modifiers= $p->modifiers();
-        if ($modifiers->isStatic() || !isset($value[$name])) {
+        if ($modifiers->isStatic() || !array_key_exists($name, $value)) {
           continue;
         } else if ($m= $reflect->method('set'.ucfirst($name))) {
           $m->invoke($r, [$this->unmarshal($value[$name], $m->parameter(0)->constraint()->type())]);

--- a/src/main/php/util/data/Marshalling.class.php
+++ b/src/main/php/util/data/Marshalling.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\data;
 
 use UnitEnum, Traversable;
-use lang\{ArrayType, Enum, MapType, Reflection, Type, XPClass};
+use lang\{ArrayType, Enum, Nullable, MapType, Reflection, Type, XPClass};
 use util\{Bytes, Currency, Date, Money, XPIterator};
 
 /**
@@ -139,6 +139,8 @@ class Marshalling {
       return $r;
     } else if ($t === Type::$ITERABLE) {
       return $this->iterable($value, Type::$VAR);
+    } else if ($t instanceof Nullable) {
+      return null === $value ? null : $this->unmarshal($value, $t->underlyingType());
     } else {
       return $t->cast($value);
     }

--- a/src/test/php/util/data/unittest/MarshallingTest.class.php
+++ b/src/test/php/util/data/unittest/MarshallingTest.class.php
@@ -33,6 +33,11 @@ class MarshallingTest {
   }
 
   #[Test]
+  public function explicit_null() {
+    Assert::equals(null, (new Marshalling())->unmarshal(['id' => null], Person::class)->id());
+  }
+
+  #[Test]
   public function nullable() {
     Assert::equals(null, (new Marshalling())->unmarshal(null, '?util.data.unittest.fixtures.Date'));
   }

--- a/src/test/php/util/data/unittest/MarshallingTest.class.php
+++ b/src/test/php/util/data/unittest/MarshallingTest.class.php
@@ -3,7 +3,7 @@
 use lang\Type;
 use test\{Assert, Test, Values};
 use util\data\Marshalling;
-use util\data\unittest\fixtures\Person;
+use util\data\unittest\fixtures\{Date, Person};
 
 class MarshallingTest {
 
@@ -30,6 +30,16 @@ class MarshallingTest {
   #[Test]
   public function unmarshal_without_type() {
     Assert::equals(1, (new Marshalling())->unmarshal(1));
+  }
+
+  #[Test]
+  public function nullable() {
+    Assert::equals(null, (new Marshalling())->unmarshal(null, '?util.data.unittest.fixtures.Date'));
+  }
+
+  #[Test, Values([1609619853, '2021-01-02T21:37:33+01:00'])]
+  public function nullable_instance($input) {
+    Assert::equals(new Date($input), (new Marshalling())->unmarshal($input, '?util.data.unittest.fixtures.Date'));
   }
 
   #[Test]

--- a/src/test/php/util/data/unittest/MarshallingTest.class.php
+++ b/src/test/php/util/data/unittest/MarshallingTest.class.php
@@ -38,12 +38,12 @@ class MarshallingTest {
   }
 
   #[Test]
-  public function nullable() {
-    Assert::equals(null, (new Marshalling())->unmarshal(null, '?util.data.unittest.fixtures.Date'));
+  public function null_as_nullable() {
+    Assert::null((new Marshalling())->unmarshal(null, '?util.data.unittest.fixtures.Date'));
   }
 
   #[Test, Values([1609619853, '2021-01-02T21:37:33+01:00'])]
-  public function nullable_instance($input) {
+  public function instance_as_nullable($input) {
     Assert::equals(new Date($input), (new Marshalling())->unmarshal($input, '?util.data.unittest.fixtures.Date'));
   }
 

--- a/src/test/php/util/data/unittest/ObjectsTest.class.php
+++ b/src/test/php/util/data/unittest/ObjectsTest.class.php
@@ -122,4 +122,20 @@ class ObjectsTest {
       (new Marshalling())->unmarshal(['token' => '098f6bcd4', 'type' => 'Bearer'], Authorization::class)
     );
   }
+
+  #[Test]
+  public function uses_default_for_omitted_property() {
+    Assert::equals(
+      new Person(0, 'Test'),
+      (new Marshalling())->unmarshal(['name' => 'Test'], Person::class)
+    );
+  }
+
+  #[Test]
+  public function ignores_excess_property() {
+    Assert::equals(
+      new Person(6100, 'Test'),
+      (new Marshalling())->unmarshal(['id' => 6100, 'name' => 'Test', 'extra' => 'Test'], Person::class)
+    );
+  }
 }

--- a/src/test/php/util/data/unittest/fixtures/Person.class.php
+++ b/src/test/php/util/data/unittest/fixtures/Person.class.php
@@ -4,7 +4,7 @@ class Person {
   private static $ROOT = 0;
 
   /** @var int */
-  private $id;
+  private $id= 0;
 
   /** @var string */
   public $name;


### PR DESCRIPTION
This pull request makes it possible to unmarshal to nullable types. Previously, this would yield a `ClassCastException`.

## Example

```php
use util\data\Marshalling;
use util\Date;

class Entry {
  public ?Date $published;
}

$m= new Marshalling();

// Property not set during unmarshalling, shown as `uninitialized(?util\Date)`
$m->unmarshal([], Entry::class);

// Property explicitely set to NULL
$m->unmarshal(['published' => null], Entry::class);

// Property unmarshalled to `new Date(time())`
$m->unmarshal(['published' => time()], Entry::class);
```
